### PR TITLE
Set up declaration-strict-value rule to enforce usage of variables

### DIFF
--- a/__tests__/scss-valid.scss
+++ b/__tests__/scss-valid.scss
@@ -1,15 +1,20 @@
+$color--blue: #4233dd;
+$font--mono: 'Courier New', Courier, monospace;
+$spacing--1: 1rem;
+$font--m: 1rem;
+
 /* valid scss */
 .helpful-button {
-    color: #4233dd;
-    font-family: 'Courier New', Courier, monospace;
-    font-size: 1rem;
+    color: $color--blue;
+    font-family: $font--mono;
+    font-size: $font--m;
 }
 
 /* valid comment containing helpful context */
 
 @mixin optionalItem($size: 1rem) {
     @if size == 1rem {
-        font-size: 1rem;
+        font-size: $size;
     } @else {
         font-size: $size;
         line-height: $size * 1.5;
@@ -18,8 +23,9 @@
 
 .logo {
     display: block;
+    /* stylelint-disable-next-line scale-unlimited/declaration-strict-value */
     color: #aaa;
-    padding: 0.9em 1.2em;
+    padding: $spacing--1;
     -webkit-font-smoothing: auto;
 }
 
@@ -28,7 +34,7 @@
         width: 20px;
         float: inline-start;
         border: 0;
-        margin-inline-end: 1em;
+        margin-inline-end: $spacing--1;
     }
 
     &:hover {

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
     'stylelint-config-recommended-scss',
     'stylelint-config-prettier-scss',
   ],
+  plugins: ['stylelint-declaration-strict-value'],
   rules: {
     'block-no-empty': true,
     'color-hex-length': 'short',
@@ -40,6 +41,33 @@ module.exports = {
     'rule-empty-line-before': [
       'always',
       { except: ['after-single-line-comment', 'first-nested'] },
+    ],
+    'scale-unlimited/declaration-strict-value': [
+      [
+        // Colors should always be defined from variables or functions.
+        '/color/',
+        'fill',
+        'stroke',
+        // Font tokens should come from our design tokens.
+        'font-family',
+        'font-size',
+        'font-weight',
+        // Spacing should use a consistent scale rather than hard-coded values.
+        '/margin/',
+        '/padding/',
+        'gap',
+        // Consistently using variables for z-index allows us to define the order of the values globally.
+        'z-index',
+      ],
+      {
+        ignoreValues: [
+          'currentColor',
+          'inherit',
+          'initial',
+          'none',
+          'transparent',
+        ],
+      },
     ],
     'scss/at-import-partial-extension': null,
     'scss/at-import-partial-extension-blacklist': ['scss'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "stylelint-config-prettier-scss": "^0.0.1",
-        "stylelint-config-recommended-scss": "^5.0.2"
+        "stylelint-config-recommended-scss": "^5.0.2",
+        "stylelint-declaration-strict-value": "^1.8.0"
       },
       "devDependencies": {
         "@wagtail/eslint-config-wagtail": "^0.3.0",
@@ -2243,6 +2244,34 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/css-shorthand-properties": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A=="
+    },
+    "node_modules/css-values": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-values/-/css-values-0.1.0.tgz",
+      "integrity": "sha1-Eot84QPU3AJ6gUpdWZXFR4HXtMY=",
+      "dependencies": {
+        "css-color-names": "0.0.4",
+        "ends-with": "^0.2.0",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "node_modules/css-values/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2475,6 +2504,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/ends-with": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+      "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -7355,6 +7392,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/shortcss": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/shortcss/-/shortcss-0.1.3.tgz",
+      "integrity": "sha1-7ip5BNgLf1UCyYQI9KLzE/qt+0g=",
+      "dependencies": {
+        "css-shorthand-properties": "^1.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -7775,6 +7820,18 @@
       },
       "peerDependencies": {
         "stylelint": "^14.0.0"
+      }
+    },
+    "node_modules/stylelint-declaration-strict-value": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.8.0.tgz",
+      "integrity": "sha512-0+DbPQMgqomlBG+uycI3PZ1BzjJ7mJA065Lx+iTg9tlmjBD36f3ZaIq1ggRZQitE0w+KcbXGzFt6axR1LIP2hw==",
+      "dependencies": {
+        "css-values": "^0.1.0",
+        "shortcss": "^0.1.3"
+      },
+      "peerDependencies": {
+        "stylelint": ">=7 <=14"
       }
     },
     "node_modules/stylelint-scss": {
@@ -10310,6 +10367,33 @@
         }
       }
     },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+    },
+    "css-shorthand-properties": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+      "integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A=="
+    },
+    "css-values": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-values/-/css-values-0.1.0.tgz",
+      "integrity": "sha1-Eot84QPU3AJ6gUpdWZXFR4HXtMY=",
+      "requires": {
+        "css-color-names": "0.0.4",
+        "ends-with": "^0.2.0",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        }
+      }
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -10486,6 +10570,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "ends-with": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
+      "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -14082,6 +14171,14 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shortcss": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/shortcss/-/shortcss-0.1.3.tgz",
+      "integrity": "sha1-7ip5BNgLf1UCyYQI9KLzE/qt+0g=",
+      "requires": {
+        "css-shorthand-properties": "^1.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -14528,6 +14625,15 @@
         "postcss-scss": "^4.0.2",
         "stylelint-config-recommended": "^6.0.0",
         "stylelint-scss": "^4.0.0"
+      }
+    },
+    "stylelint-declaration-strict-value": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.8.0.tgz",
+      "integrity": "sha512-0+DbPQMgqomlBG+uycI3PZ1BzjJ7mJA065Lx+iTg9tlmjBD36f3ZaIq1ggRZQitE0w+KcbXGzFt6axR1LIP2hw==",
+      "requires": {
+        "css-values": "^0.1.0",
+        "shortcss": "^0.1.3"
       }
     },
     "stylelint-scss": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "stylelint-config-prettier-scss": "^0.0.1",
-    "stylelint-config-recommended-scss": "^5.0.2"
+    "stylelint-config-recommended-scss": "^5.0.2",
+    "stylelint-declaration-strict-value": "^1.8.0"
   },
   "devDependencies": {
     "@wagtail/eslint-config-wagtail": "^0.3.0",


### PR DESCRIPTION
Addresses #6. This introduces [stylelint-declaration-strict-value](https://github.com/AndyOGo/stylelint-declaration-strict-value), which helps to enforce declarations only use variables, functions, or a list of allowed keywords.

The main reason for doing this is to enforce those values are centrally defined so we can ensure consistency.