### PR TITLE
Use stylelint built-in rules to disallow left/right positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update internal package nanoid version.
+- Start enforcing [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties) so that projects can better RTL.
 
 ## [0.3.2](https://github.com/wagtail/stylelint-config-wagtail/releases/tag/v0.3.2) - 2021-12-23
 

--- a/__tests__/scss-invalid.scss
+++ b/__tests__/scss-invalid.scss
@@ -69,3 +69,13 @@
         line-height: $size * 1.5;
     }
 }
+
+/* declaration-property-value-allowed-list */
+/* property-disallowed-list */
+
+.wagtail-logo {
+    border: 0;
+    float: left;
+    margin-right: 1em;
+    text-align: right;
+}

--- a/__tests__/scss-valid.scss
+++ b/__tests__/scss-valid.scss
@@ -26,9 +26,9 @@
 .wagtail-logo-container__mobile {
     .wagtail-logo {
         width: 20px;
-        float: left;
+        float: inline-start;
         border: 0;
-        margin-right: 1em;
+        margin-inline-end: 1em;
     }
 
     &:hover {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ module.exports = {
     'declaration-block-no-duplicate-properties': true,
     'declaration-block-no-redundant-longhand-properties': true,
     'declaration-block-single-line-max-declarations': 1,
+    'declaration-property-value-allowed-list': {
+      // Only allow logical values.
+      'clear': ['both'],
+      'float': ['inline-start', 'inline-end'],
+      'text-align': ['start', 'end', 'center'],
+    },
     'declaration-property-value-disallowed-list': [
       { '/^border/': ['none'] },
       { severity: 'error' },
@@ -24,6 +30,11 @@ module.exports = {
     'max-nesting-depth': 3,
     'media-feature-name-no-unknown': true,
     'no-empty-source': true,
+    'property-disallowed-list': [
+      // Disallow positioning with physical properties. Use logical ones instead.
+      '/left/',
+      '/right/',
+    ],
     'property-no-unknown': true,
     'property-no-vendor-prefix': true,
     'rule-empty-line-before': [


### PR DESCRIPTION
This is the first step towards [RTL language support](https://github.com/wagtail/wagtail/discussions/7793). We need to stop using physical left/right properties for positioning, and instead enforce usage of [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

At this stage we’re not considering any support for vertical layouts, so it’s really only "left" and "right" concepts we need to disallow and replace with "inline start" and "inline end".