### PR TITLE
add convenience print-config script

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lint:js": "eslint ./ --max-warnings 0",
     "lint": "npm run lint:format && npm run lint:js",
     "preflight": "npm run format && npm run lint && npm run test",
+    "print-config": "stylelint --print-config .stylelintrc",
     "test": "jest"
   },
   "prettier": {


### PR DESCRIPTION
I find myself adding this often when wanting check the full output - thought it would be nice to include this script by default.