### PR TITLE
Upgrade to Stylelint v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to Stylelint 17, and latest version of other config/plugin packages.
+
+#### New rules configuration
+
+| Rule                                                                                                                                     | Purpose                                                                                        | Set to                                                                                                                        | Was set to                                |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| [`scss/selector-class-pattern`](https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-class-pattern/README.md) | Replaces `selector-class-pattern`. Require or disallow a specific pattern for class selectors. | `/^[a-z]+[0-9]{0,2}(-[a-z0-9]+)*(__[a-z0-9]+(-[a-z0-9]+)*)?(--[a-z0-9]+(-[a-z0-9]+)*)?$/` with `resolveNestedSelectors: true` | `selector-class-pattern` with same config |
+
+### BREAKING CHANGES
+
+The configuration now mandates stylelint v17. See Stylelint's official [Migrating to 17.0.0](https://stylelint.io/migration-guide/to-17) documentation for more details.
+
+#### Migration notes
+
+- `selector-class-pattern` has been replaced with `scss/selector-class-pattern` because Stylelint 17 removed the `resolveNestedSelectors` option from the core rule. The SCSS plugin provides an equivalent rule with this option.
+- Several rules now behave differently with CSS nesting due to Stylelint 17's changes to standard CSS nesting support:
+  - `selector-max-*` rules no longer desugar nesting
+  - `no-duplicate-selectors` and `selector-no-qualifying-type` now resolve selectors according to standard CSS nesting
+
 ## [1.0.1](https://github.com/wagtail/stylelint-config-wagtail/releases/tag/1.0.1) - 2026-03-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Our default export contains all of our Stylelint rules, along with specific plugins for SCSS syntax.
 
 1. Run `npm install stylelint @wagtail/stylelint-config-wagtail --save-dev`
-2. Add `"extends": "@wagtail/stylelint-config-wagtail"` to your `.stylelintrc`
+2. Add `"extends": "@wagtail/stylelint-config-wagtail"` to your Stylelint configuration
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -51,137 +51,147 @@ Our default export contains all of our Stylelint rules, along with specific plug
 
 | Rule                                                         | Config                                                              |
 | ------------------------------------------------------------ | ------------------------------------------------------------------- |
-| [`block-no-empty`][0]                                        | Enabled                                                             |
-| [`color-hex-length`][1]                                      | `"short"`                                                           |
-| [`color-named`][2]                                           | `"never"`                                                           |
-| [`color-no-invalid-hex`][3]                                  | Enabled                                                             |
-| [`comment-no-empty`][4]                                      | Enabled                                                             |
-| [`custom-property-no-missing-var-function`][5]               | Enabled                                                             |
-| [`declaration-block-no-duplicate-custom-properties`][6]      | Enabled                                                             |
-| [`declaration-block-no-duplicate-properties`][7]             | Enabled                                                             |
-| [`declaration-block-no-redundant-longhand-properties`][8]    | Enabled                                                             |
-| [`declaration-block-no-shorthand-property-overrides`][9]     | Enabled                                                             |
-| [`declaration-block-single-line-max-declarations`][10]       | `1`                                                                 |
-| [`declaration-no-important`][11]                             | Enabled                                                             |
-| [`declaration-property-value-allowed-list`][12]              | Enabled - [see Config][config]                                      |
-| [`declaration-property-value-disallowed-list`][13]           | `{"/^border/":["none"]}, {"severity":"error"}`                      |
-| [`font-family-no-duplicate-names`][14]                       | Enabled                                                             |
-| [`font-family-no-missing-generic-family-keyword`][15]        | Enabled                                                             |
-| [`function-calc-no-unspaced-operator`][16]                   | Enabled                                                             |
-| [`function-linear-gradient-no-nonstandard-direction`][17]    | Enabled                                                             |
-| [`function-url-quotes`][18]                                  | `"always"`                                                          |
-| [`keyframe-block-no-duplicate-selectors`][19]                | Enabled                                                             |
-| [`keyframe-declaration-no-important`][20]                    | Enabled                                                             |
-| [`length-zero-no-unit`][21]                                  | Enabled                                                             |
-| [`max-nesting-depth`][22]                                    | `3`                                                                 |
-| [`media-feature-name-no-unknown`][23]                        | Enabled                                                             |
-| [`named-grid-areas-no-invalid`][24]                          | Enabled                                                             |
-| [`no-descending-specificity`][25]                            | Enabled                                                             |
-| [`no-duplicate-at-import-rules`][26]                         | Enabled                                                             |
-| [`no-duplicate-selectors`][27]                               | Enabled                                                             |
-| [`no-empty-source`][28]                                      | Enabled                                                             |
-| [`no-invalid-double-slash-comments`][29]                     | Enabled                                                             |
-| [`no-invalid-position-at-import-rule`][30]                   | `{"ignoreAtRules":["use","forward"]}`                               |
-| [`no-irregular-whitespace`][31]                              | Enabled                                                             |
-| [`order/order`][32]                                          | `[{"name":"include","type":"at-rule"},"declarations"]`              |
-| [`property-disallowed-list`][33]                             | `["/forced-color-adjust/","/left/","/right/","text-transform"]`     |
-| [`property-no-unknown`][34]                                  | Enabled                                                             |
-| [`property-no-vendor-prefix`][35]                            | Enabled                                                             |
-| [`rule-empty-line-before`][36]                               | `"always", {"except":["after-single-line-comment","first-nested"]}` |
-| [`scale-unlimited/declaration-strict-value`][37]             | Enabled - [see Config][config]                                      |
-| [`scss/at-extend-no-missing-placeholder`][38]                | Enabled                                                             |
-| [`scss/at-if-no-null`][39]                                   | Enabled                                                             |
-| [`scss/at-rule-no-unknown`][40]                              | Enabled                                                             |
-| [`scss/comment-no-empty`][41]                                | Enabled                                                             |
-| [`scss/declaration-nested-properties-no-divided-groups`][42] | Enabled                                                             |
-| [`scss/dollar-variable-no-missing-interpolation`][43]        | Enabled                                                             |
-| [`scss/function-quote-no-quoted-strings-inside`][44]         | Enabled                                                             |
-| [`scss/function-unquote-no-unquoted-strings-inside`][45]     | Enabled                                                             |
-| [`scss/load-no-partial-leading-underscore`][46]              | Enabled                                                             |
-| [`scss/load-partial-extension`][47]                          | `"never"`                                                           |
-| [`scss/media-feature-value-dollar-variable`][48]             | `"always", {"ignore":["keywords"]}`                                 |
-| [`scss/no-duplicate-mixins`][49]                             | Enabled                                                             |
-| [`scss/no-global-function-names`][50]                        | Enabled                                                             |
-| [`scss/selector-no-redundant-nesting-selector`][51]          | Enabled                                                             |
-| [`scss/selector-no-union-class-name`][52]                    | Enabled                                                             |
-| [`selector-anb-no-unmatchable`][53]                          | Enabled                                                             |
-| [`selector-attribute-name-disallowed-list`][54]              | `"/^data-/"`                                                        |
-| [`selector-class-pattern`][55]                               | `{}, {"resolveNestedSelectors":true}`                               |
-| [`selector-max-combinators`][56]                             | `3`                                                                 |
-| [`selector-max-id`][57]                                      | `0`                                                                 |
-| [`selector-max-specificity`][58]                             | `"0,3,3"`                                                           |
-| [`selector-no-qualifying-type`][59]                          | `{"ignore":["attribute","class"]}`                                  |
-| [`selector-pseudo-class-no-unknown`][60]                     | Enabled                                                             |
-| [`selector-pseudo-element-no-unknown`][61]                   | Enabled                                                             |
-| [`selector-type-no-unknown`][62]                             | Enabled                                                             |
-| [`string-no-newline`][63]                                    | Enabled                                                             |
-| [`unit-no-unknown`][64]                                      | Enabled                                                             |
-| [`value-no-vendor-prefix`][65]                               | Enabled                                                             |
+| [`at-rule-no-deprecated`][0]                                 | Enabled                                                             |
+| [`block-no-empty`][1]                                        | Enabled                                                             |
+| [`color-hex-length`][2]                                      | `"short"`                                                           |
+| [`color-named`][3]                                           | `"never"`                                                           |
+| [`color-no-invalid-hex`][4]                                  | Enabled                                                             |
+| [`comment-no-empty`][5]                                      | Enabled                                                             |
+| [`custom-property-no-missing-var-function`][6]               | Enabled                                                             |
+| [`declaration-block-no-duplicate-custom-properties`][7]      | Enabled                                                             |
+| [`declaration-block-no-duplicate-properties`][8]             | Enabled                                                             |
+| [`declaration-block-no-redundant-longhand-properties`][9]    | Enabled                                                             |
+| [`declaration-block-no-shorthand-property-overrides`][10]    | Enabled                                                             |
+| [`declaration-block-single-line-max-declarations`][11]       | `1`                                                                 |
+| [`declaration-no-important`][12]                             | Enabled                                                             |
+| [`declaration-property-value-allowed-list`][13]              | Enabled - [see Config][config]                                      |
+| [`declaration-property-value-disallowed-list`][14]           | `{"/^border/":["none"]}, {"severity":"error"}`                      |
+| [`declaration-property-value-keyword-no-deprecated`][15]     | Enabled                                                             |
+| [`font-family-no-duplicate-names`][16]                       | Enabled                                                             |
+| [`font-family-no-missing-generic-family-keyword`][17]        | Enabled                                                             |
+| [`function-calc-no-unspaced-operator`][18]                   | Enabled                                                             |
+| [`function-linear-gradient-no-nonstandard-direction`][19]    | Enabled                                                             |
+| [`function-url-quotes`][20]                                  | `"always"`                                                          |
+| [`keyframe-block-no-duplicate-selectors`][21]                | Enabled                                                             |
+| [`keyframe-declaration-no-important`][22]                    | Enabled                                                             |
+| [`length-zero-no-unit`][23]                                  | Enabled                                                             |
+| [`max-nesting-depth`][24]                                    | `3`                                                                 |
+| [`media-feature-name-no-unknown`][25]                        | Enabled                                                             |
+| [`media-type-no-deprecated`][26]                             | Enabled                                                             |
+| [`named-grid-areas-no-invalid`][27]                          | Enabled                                                             |
+| [`nesting-selector-no-missing-scoping-root`][28]             | `{"ignoreAtRules":["mixin"]}`                                       |
+| [`no-duplicate-at-import-rules`][29]                         | Enabled                                                             |
+| [`no-empty-source`][30]                                      | Enabled                                                             |
+| [`no-invalid-double-slash-comments`][31]                     | Enabled                                                             |
+| [`no-invalid-position-at-import-rule`][32]                   | `{"ignoreAtRules":["use","forward"]}`                               |
+| [`no-invalid-position-declaration`][33]                      | Enabled                                                             |
+| [`no-irregular-whitespace`][34]                              | Enabled                                                             |
+| [`order/order`][35]                                          | `[{"name":"include","type":"at-rule"},"declarations"]`              |
+| [`property-disallowed-list`][36]                             | `["/forced-color-adjust/","/left/","/right/","text-transform"]`     |
+| [`property-no-deprecated`][37]                               | Enabled                                                             |
+| [`property-no-unknown`][38]                                  | Enabled                                                             |
+| [`property-no-vendor-prefix`][39]                            | Enabled                                                             |
+| [`rule-empty-line-before`][40]                               | `"always", {"except":["after-single-line-comment","first-nested"]}` |
+| [`scale-unlimited/declaration-strict-value`][41]             | Enabled - [see Config][config]                                      |
+| [`scss/at-extend-no-missing-placeholder`][42]                | Enabled                                                             |
+| [`scss/at-if-no-null`][43]                                   | Enabled                                                             |
+| [`scss/at-rule-no-unknown`][44]                              | Enabled                                                             |
+| [`scss/comment-no-empty`][45]                                | Enabled                                                             |
+| [`scss/declaration-nested-properties-no-divided-groups`][46] | Enabled                                                             |
+| [`scss/dollar-variable-no-missing-interpolation`][47]        | Enabled                                                             |
+| [`scss/function-quote-no-quoted-strings-inside`][48]         | Enabled                                                             |
+| [`scss/function-unquote-no-unquoted-strings-inside`][49]     | Enabled                                                             |
+| [`scss/load-no-partial-leading-underscore`][50]              | Enabled                                                             |
+| [`scss/load-partial-extension`][51]                          | `"never"`                                                           |
+| [`scss/media-feature-value-dollar-variable`][52]             | `"always", {"ignore":["keywords"]}`                                 |
+| [`scss/no-duplicate-mixins`][53]                             | Enabled                                                             |
+| [`scss/no-global-function-names`][54]                        | Enabled                                                             |
+| [`scss/selector-class-pattern`][55]                          | `{}, {"resolveNestedSelectors":true}`                               |
+| [`scss/selector-no-redundant-nesting-selector`][56]          | Enabled                                                             |
+| [`scss/selector-no-union-class-name`][57]                    | Enabled                                                             |
+| [`selector-anb-no-unmatchable`][58]                          | Enabled                                                             |
+| [`selector-attribute-name-disallowed-list`][59]              | `"/^data-/"`                                                        |
+| [`selector-max-combinators`][60]                             | `3`                                                                 |
+| [`selector-max-id`][61]                                      | `0`                                                                 |
+| [`selector-max-specificity`][62]                             | `"0,3,3"`                                                           |
+| [`selector-no-qualifying-type`][63]                          | `{"ignore":["attribute","class"]}`                                  |
+| [`selector-pseudo-class-no-unknown`][64]                     | Enabled                                                             |
+| [`selector-pseudo-element-no-unknown`][65]                   | Enabled                                                             |
+| [`selector-type-no-unknown`][66]                             | Enabled                                                             |
+| [`string-no-newline`][67]                                    | Enabled                                                             |
+| [`syntax-string-no-invalid`][68]                             | Enabled                                                             |
+| [`unit-no-unknown`][69]                                      | Enabled                                                             |
+| [`value-no-vendor-prefix`][70]                               | Enabled                                                             |
 
 [config]: https://github.com/wagtail/stylelint-config-wagtail/blob/main/index.js
-[0]: https://stylelint.io/user-guide/rules/list/block-no-empty/
-[1]: https://stylelint.io/user-guide/rules/list/color-hex-length/
-[2]: https://stylelint.io/user-guide/rules/list/color-named/
-[3]: https://stylelint.io/user-guide/rules/list/color-no-invalid-hex/
-[4]: https://stylelint.io/user-guide/rules/list/comment-no-empty/
-[5]: https://stylelint.io/user-guide/rules/list/custom-property-no-missing-var-function/
-[6]: https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-custom-properties/
-[7]: https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties/
-[8]: https://stylelint.io/user-guide/rules/list/declaration-block-no-redundant-longhand-properties/
-[9]: https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides/
-[10]: https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations/
-[11]: https://stylelint.io/user-guide/rules/list/declaration-no-important/
-[12]: https://stylelint.io/user-guide/rules/list/declaration-property-value-allowed-list/
-[13]: https://stylelint.io/user-guide/rules/list/declaration-property-value-disallowed-list/
-[14]: https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names/
-[15]: https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword/
-[16]: https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator/
-[17]: https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction/
-[18]: https://stylelint.io/user-guide/rules/list/function-url-quotes/
-[19]: https://stylelint.io/user-guide/rules/list/keyframe-block-no-duplicate-selectors/
-[20]: https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important/
-[21]: https://stylelint.io/user-guide/rules/list/length-zero-no-unit/
-[22]: https://stylelint.io/user-guide/rules/list/max-nesting-depth/
-[23]: https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown/
-[24]: https://stylelint.io/user-guide/rules/list/named-grid-areas-no-invalid/
-[25]: https://stylelint.io/user-guide/rules/list/no-descending-specificity/
-[26]: https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules/
-[27]: https://stylelint.io/user-guide/rules/list/no-duplicate-selectors/
-[28]: https://stylelint.io/user-guide/rules/list/no-empty-source/
-[29]: https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments/
-[30]: https://stylelint.io/user-guide/rules/list/no-invalid-position-at-import-rule/
-[31]: https://stylelint.io/user-guide/rules/list/no-irregular-whitespace/
-[32]: https://github.com/hudochenkov/stylelint-order/blob/master/rules/order/README.md
-[33]: https://stylelint.io/user-guide/rules/list/property-disallowed-list/
-[34]: https://stylelint.io/user-guide/rules/list/property-no-unknown/
-[35]: https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix/
-[36]: https://stylelint.io/user-guide/rules/list/rule-empty-line-before/
-[37]: https://github.com/AndyOGo/stylelint-declaration-strict-value
-[38]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-extend-no-missing-placeholder/README.md
-[39]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-if-no-null/README.md
-[40]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-rule-no-unknown/README.md
-[41]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/comment-no-empty/README.md
-[42]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/declaration-nested-properties-no-divided-groups/README.md
-[43]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-no-missing-interpolation/README.md
-[44]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-quote-no-quoted-strings-inside/README.md
-[45]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-unquote-no-unquoted-strings-inside/README.md
-[46]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/load-no-partial-leading-underscore/README.md
-[47]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/load-partial-extension/README.md
-[48]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/media-feature-value-dollar-variable/README.md
-[49]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-duplicate-mixins/README.md
-[50]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-global-function-names/README.md
-[51]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md
-[52]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-no-union-class-name/README.md
-[53]: https://stylelint.io/user-guide/rules/list/selector-anb-no-unmatchable/
-[54]: https://stylelint.io/user-guide/rules/list/selector-attribute-name-disallowed-list/
-[55]: https://stylelint.io/user-guide/rules/list/selector-class-pattern/
-[56]: https://stylelint.io/user-guide/rules/list/selector-max-combinators/
-[57]: https://stylelint.io/user-guide/rules/list/selector-max-id/
-[58]: https://stylelint.io/user-guide/rules/list/selector-max-specificity/
-[59]: https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type/
-[60]: https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown/
-[61]: https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown/
-[62]: https://stylelint.io/user-guide/rules/list/selector-type-no-unknown/
-[63]: https://stylelint.io/user-guide/rules/list/string-no-newline/
-[64]: https://stylelint.io/user-guide/rules/list/unit-no-unknown/
-[65]: https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix/
+[0]: https://stylelint.io/user-guide/rules/list/at-rule-no-deprecated/
+[1]: https://stylelint.io/user-guide/rules/list/block-no-empty/
+[2]: https://stylelint.io/user-guide/rules/list/color-hex-length/
+[3]: https://stylelint.io/user-guide/rules/list/color-named/
+[4]: https://stylelint.io/user-guide/rules/list/color-no-invalid-hex/
+[5]: https://stylelint.io/user-guide/rules/list/comment-no-empty/
+[6]: https://stylelint.io/user-guide/rules/list/custom-property-no-missing-var-function/
+[7]: https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-custom-properties/
+[8]: https://stylelint.io/user-guide/rules/list/declaration-block-no-duplicate-properties/
+[9]: https://stylelint.io/user-guide/rules/list/declaration-block-no-redundant-longhand-properties/
+[10]: https://stylelint.io/user-guide/rules/list/declaration-block-no-shorthand-property-overrides/
+[11]: https://stylelint.io/user-guide/rules/list/declaration-block-single-line-max-declarations/
+[12]: https://stylelint.io/user-guide/rules/list/declaration-no-important/
+[13]: https://stylelint.io/user-guide/rules/list/declaration-property-value-allowed-list/
+[14]: https://stylelint.io/user-guide/rules/list/declaration-property-value-disallowed-list/
+[15]: https://stylelint.io/user-guide/rules/list/declaration-property-value-keyword-no-deprecated/
+[16]: https://stylelint.io/user-guide/rules/list/font-family-no-duplicate-names/
+[17]: https://stylelint.io/user-guide/rules/list/font-family-no-missing-generic-family-keyword/
+[18]: https://stylelint.io/user-guide/rules/list/function-calc-no-unspaced-operator/
+[19]: https://stylelint.io/user-guide/rules/list/function-linear-gradient-no-nonstandard-direction/
+[20]: https://stylelint.io/user-guide/rules/list/function-url-quotes/
+[21]: https://stylelint.io/user-guide/rules/list/keyframe-block-no-duplicate-selectors/
+[22]: https://stylelint.io/user-guide/rules/list/keyframe-declaration-no-important/
+[23]: https://stylelint.io/user-guide/rules/list/length-zero-no-unit/
+[24]: https://stylelint.io/user-guide/rules/list/max-nesting-depth/
+[25]: https://stylelint.io/user-guide/rules/list/media-feature-name-no-unknown/
+[26]: https://stylelint.io/user-guide/rules/list/media-type-no-deprecated/
+[27]: https://stylelint.io/user-guide/rules/list/named-grid-areas-no-invalid/
+[28]: https://stylelint.io/user-guide/rules/list/nesting-selector-no-missing-scoping-root/
+[29]: https://stylelint.io/user-guide/rules/list/no-duplicate-at-import-rules/
+[30]: https://stylelint.io/user-guide/rules/list/no-empty-source/
+[31]: https://stylelint.io/user-guide/rules/list/no-invalid-double-slash-comments/
+[32]: https://stylelint.io/user-guide/rules/list/no-invalid-position-at-import-rule/
+[33]: https://stylelint.io/user-guide/rules/list/no-invalid-position-declaration/
+[34]: https://stylelint.io/user-guide/rules/list/no-irregular-whitespace/
+[35]: https://github.com/hudochenkov/stylelint-order/blob/master/rules/order/README.md
+[36]: https://stylelint.io/user-guide/rules/list/property-disallowed-list/
+[37]: https://stylelint.io/user-guide/rules/list/property-no-deprecated/
+[38]: https://stylelint.io/user-guide/rules/list/property-no-unknown/
+[39]: https://stylelint.io/user-guide/rules/list/property-no-vendor-prefix/
+[40]: https://stylelint.io/user-guide/rules/list/rule-empty-line-before/
+[41]: https://github.com/AndyOGo/stylelint-declaration-strict-value
+[42]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-extend-no-missing-placeholder/README.md
+[43]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-if-no-null/README.md
+[44]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-rule-no-unknown/README.md
+[45]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/comment-no-empty/README.md
+[46]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/declaration-nested-properties-no-divided-groups/README.md
+[47]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/dollar-variable-no-missing-interpolation/README.md
+[48]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-quote-no-quoted-strings-inside/README.md
+[49]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/function-unquote-no-unquoted-strings-inside/README.md
+[50]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/load-no-partial-leading-underscore/README.md
+[51]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/load-partial-extension/README.md
+[52]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/media-feature-value-dollar-variable/README.md
+[53]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-duplicate-mixins/README.md
+[54]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/no-global-function-names/README.md
+[55]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-class-pattern/README.md
+[56]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-no-redundant-nesting-selector/README.md
+[57]: https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/selector-no-union-class-name/README.md
+[58]: https://stylelint.io/user-guide/rules/list/selector-anb-no-unmatchable/
+[59]: https://stylelint.io/user-guide/rules/list/selector-attribute-name-disallowed-list/
+[60]: https://stylelint.io/user-guide/rules/list/selector-max-combinators/
+[61]: https://stylelint.io/user-guide/rules/list/selector-max-id/
+[62]: https://stylelint.io/user-guide/rules/list/selector-max-specificity/
+[63]: https://stylelint.io/user-guide/rules/list/selector-no-qualifying-type/
+[64]: https://stylelint.io/user-guide/rules/list/selector-pseudo-class-no-unknown/
+[65]: https://stylelint.io/user-guide/rules/list/selector-pseudo-element-no-unknown/
+[66]: https://stylelint.io/user-guide/rules/list/selector-type-no-unknown/
+[67]: https://stylelint.io/user-guide/rules/list/string-no-newline/
+[68]: https://stylelint.io/user-guide/rules/list/syntax-string-no-invalid/
+[69]: https://stylelint.io/user-guide/rules/list/unit-no-unknown/
+[70]: https://stylelint.io/user-guide/rules/list/value-no-vendor-prefix/

--- a/__tests__/index.test.mjs
+++ b/__tests__/index.test.mjs
@@ -31,7 +31,7 @@ describe('flags warnings with invalid css', () => {
 
     assert.equal(errored, true);
 
-    assert.strictEqual(results[0].warnings.length, 47);
+    assert.strictEqual(results[0].warnings.length, 46);
 
     assert.deepStrictEqual(
       results[0].warnings
@@ -58,10 +58,10 @@ describe('flags warnings with invalid css', () => {
         'scale-unlimited/declaration-strict-value': 9,
         'scss/at-rule-no-unknown': 1,
         'scss/comment-no-empty': 1,
+        'scss/selector-class-pattern': 2,
         'scss/selector-no-union-class-name': 1,
         'selector-attribute-name-disallowed-list': 1,
-        'selector-class-pattern': 2,
-        'selector-max-combinators': 2,
+        'selector-max-combinators': 1,
         'selector-max-id': 1,
         'selector-max-specificity': 5,
         'unit-no-unknown': 1,

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ module.exports = {
     'scss/selector-no-redundant-nesting-selector': true,
     'scss/selector-no-union-class-name': true,
     'selector-attribute-name-disallowed-list': '/^data-/',
-    'selector-class-pattern': [
+    'scss/selector-class-pattern': [
       // Loose pattern for hyphenated BEM. This also allows simple words to be used as class names, .e.g. `.active`, `.button`.
       // Based on:
       // - https://github.com/postcss/postcss-bem-linter/issues/89#issuecomment-255482072

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,18 @@
       "license": "MIT",
       "dependencies": {
         "stylelint-config-prettier-scss": "^1.0.0",
-        "stylelint-config-recommended-scss": "17.0.0",
-        "stylelint-declaration-strict-value": "1.11.0",
-        "stylelint-order": "7.0.1"
+        "stylelint-config-recommended-scss": "^17.0.0",
+        "stylelint-declaration-strict-value": "^1.11.0",
+        "stylelint-order": "^7.0.1"
       },
       "devDependencies": {
         "@wagtail/eslint-config-wagtail": "^0.4.0",
         "eslint": "^8.57.0",
         "prettier": "^3.3.3",
-        "stylelint": "17.9.0"
+        "stylelint": "^17.9.0"
       },
       "peerDependencies": {
-        "stylelint": ">=16.10.0"
+        "stylelint": ">=17.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,27 +10,27 @@
       "license": "MIT",
       "dependencies": {
         "stylelint-config-prettier-scss": "^1.0.0",
-        "stylelint-config-recommended-scss": "^14.1.0",
-        "stylelint-declaration-strict-value": "^1.10.6",
-        "stylelint-order": "^6.0.4"
+        "stylelint-config-recommended-scss": "17.0.0",
+        "stylelint-declaration-strict-value": "1.11.0",
+        "stylelint-order": "7.0.1"
       },
       "devDependencies": {
         "@wagtail/eslint-config-wagtail": "^0.4.0",
         "eslint": "^8.57.0",
         "prettier": "^3.3.3",
-        "stylelint": "16.10.0"
+        "stylelint": "17.9.0"
       },
       "peerDependencies": {
         "stylelint": ">=16.10.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -47,10 +47,66 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+      "integrity": "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "funding": [
         {
           "type": "github",
@@ -63,16 +119,63 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.4"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
       "funding": [
         {
           "type": "github",
@@ -85,13 +188,13 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-3.0.1.tgz",
-      "integrity": "sha512-HNo8gGD02kHmcbX6PvCoUuOQvn4szyB9ca63vZHKX5A81QytgDG4oxG4IaEfHTlEZSZ6MjPEMWIVU+zF2PZcgw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
       "funding": [
         {
           "type": "github",
@@ -104,17 +207,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1"
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
       }
     },
-    "node_modules/@csstools/selector-specificity": {
+    "node_modules/@csstools/selector-resolve-nested": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-4.0.0.tgz",
-      "integrity": "sha512-189nelqtPd8++phaHNwYovKZI0FOzH1vQEE3QhHHkNIGrg5fSs9CbYP3RvfEH5geztnIA9Jwq91wyOIwAW5JIQ==",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
       "funding": [
         {
           "type": "github",
@@ -127,20 +230,32 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=18"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "postcss-selector-parser": "^6.1.0"
+        "postcss-selector-parser": "^7.1.1"
       }
     },
-    "node_modules/@dual-bundle/import-meta-resolve": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
-      "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/JounQin"
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -244,6 +359,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -286,6 +407,18 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -439,15 +572,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -673,6 +797,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+      "integrity": "sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.9.0"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -792,9 +938,9 @@
       "peer": true
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -833,22 +979,22 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12 || >=16"
+        "node": ">=12"
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
@@ -991,18 +1137,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -1833,9 +1967,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/for-each": {
@@ -1915,6 +2049,18 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2085,20 +2231,41 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2149,6 +2316,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2216,6 +2384,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -2230,13 +2410,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "license": "MIT"
+    },
     "node_modules/html-tags": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
-      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2246,6 +2432,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -2267,10 +2454,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -2817,6 +3015,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -2874,6 +3073,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -2889,9 +3089,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.34.0.tgz",
-      "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
       "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
@@ -2991,9 +3191,9 @@
       }
     },
     "node_modules/mathml-tag-names": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
-      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3001,18 +3201,18 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
     },
     "node_modules/meow": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
-      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3382,15 +3582,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3398,9 +3589,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3421,9 +3612,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3513,9 +3704,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3526,9 +3717,9 @@
       }
     },
     "node_modules/postcss-sorting": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
-      "integrity": "sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-9.1.0.tgz",
+      "integrity": "sha512-Mn8KJ45HNNG6JBpBizXcyf6LqY/qyqetGcou/nprDnFwBFBLGj0j/sNKV2lj2KMOVOwdXu14aEzqJv8CIV6e8g==",
       "license": "MIT",
       "peerDependencies": {
         "postcss": "^8.4.20"
@@ -3588,6 +3779,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qified": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
+      "integrity": "sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==",
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz",
+      "integrity": "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -3990,12 +4199,15 @@
       }
     },
     "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slice-ansi": {
@@ -4215,9 +4427,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.10.0.tgz",
-      "integrity": "sha512-z/8X2rZ52dt2c0stVwI9QL2AFJhLhbPkyfpDFcizs200V/g7v+UYY6SNcB9hKOLcDDX/yGLDsY/pX08sLkz9xQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.9.0.tgz",
+      "integrity": "sha512-xO0jeY6z1/urFL5L/BZLmB1yYlbRiRMQnYH6ArZIDWJ+SZXGssOY7XoYb1JIv/L220+EBnwwJXJS4Mt/F96SvA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4230,50 +4442,48 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.1",
-        "@csstools/css-tokenizer": "^3.0.1",
-        "@csstools/media-query-list-parser": "^3.0.1",
-        "@csstools/selector-specificity": "^4.0.0",
-        "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "balanced-match": "^2.0.0",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
         "colord": "^2.9.3",
-        "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.3",
-        "css-tree": "^3.0.0",
-        "debug": "^4.3.7",
-        "fast-glob": "^3.3.2",
+        "cosmiconfig": "^9.0.1",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
         "fastest-levenshtein": "^1.0.16",
-        "file-entry-cache": "^9.1.0",
+        "file-entry-cache": "^11.1.2",
         "global-modules": "^2.0.0",
-        "globby": "^11.1.0",
+        "globby": "^16.2.0",
         "globjoin": "^0.1.4",
-        "html-tags": "^3.3.1",
-        "ignore": "^6.0.2",
-        "imurmurhash": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.34.0",
-        "mathml-tag-names": "^2.1.3",
-        "meow": "^13.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
         "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
-        "picocolors": "^1.0.1",
-        "postcss": "^8.4.47",
-        "postcss-resolve-nested-selector": "^0.1.6",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.9",
         "postcss-safe-parser": "^7.0.1",
-        "postcss-selector-parser": "^6.1.2",
+        "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0",
-        "resolve-from": "^5.0.0",
-        "string-width": "^4.2.3",
-        "supports-hyperlinks": "^3.1.0",
+        "string-width": "^8.2.0",
+        "supports-hyperlinks": "^4.4.0",
         "svg-tags": "^1.0.0",
-        "table": "^6.8.2",
-        "write-file-atomic": "^5.0.1"
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
       },
       "bin": {
         "stylelint": "bin/stylelint.mjs"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/stylelint-config-prettier-scss": {
@@ -4293,9 +4503,9 @@
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
-      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4308,28 +4518,28 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.1.0"
+        "stylelint": "^17.0.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
-      "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-17.0.0.tgz",
+      "integrity": "sha512-VkVD9r7jfUT/dq3mA3/I1WXXk2U71rO5wvU2yIil9PW5o1g3UM7Xc82vHmuVJHV7Y8ok5K137fmW5u3HbhtTOA==",
       "license": "MIT",
       "dependencies": {
         "postcss-scss": "^4.0.9",
-        "stylelint-config-recommended": "^14.0.1",
-        "stylelint-scss": "^6.4.0"
+        "stylelint-config-recommended": "^18.0.0",
+        "stylelint-scss": "^7.0.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20"
       },
       "peerDependencies": {
         "postcss": "^8.3.3",
-        "stylelint": "^16.6.1"
+        "stylelint": "^17.0.0"
       },
       "peerDependenciesMeta": {
         "postcss": {
@@ -4338,34 +4548,37 @@
       }
     },
     "node_modules/stylelint-declaration-strict-value": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.10.11.tgz",
-      "integrity": "sha512-oVQvhZlFZAiDz9r2BPFZLtTGm1A2JVhdKObKAJoTjFfR4F/NpApC4bMBTxf4sZS76Na3njYKVOaAaKSZ4+FU+g==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.11.0.tgz",
+      "integrity": "sha512-rGU27HLSQScIQ6ZbCcoVLXf07fy6ijczbxFYv0RnGwIZrVXIr8Sz9TRV5QbjU8E7nOlD4BQEAfRgeQsFaQXX3g==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": ">=7 <=16"
+        "stylelint": ">=16 <=17"
       }
     },
     "node_modules/stylelint-order": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.4.tgz",
-      "integrity": "sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-7.0.1.tgz",
+      "integrity": "sha512-GWPei1zBVDDjxM+/BmcSCiOcHNd8rSqW6FUZtqQGlTRpD0Z5nSzspzWD8rtKif5KPdzUG68DApKEV/y/I9VbTw==",
       "license": "MIT",
       "dependencies": {
-        "postcss": "^8.4.32",
-        "postcss-sorting": "^8.0.2"
+        "postcss": "^8.5.6",
+        "postcss-sorting": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
+        "stylelint": "^16.18.0 || ^17.0.0"
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.13.0.tgz",
-      "integrity": "sha512-kZPwFUJkfup2gP1enlrS2h9U5+T5wFoqzJ1n/56AlpwSj28kmFe7ww/QFydvPsg5gLjWchAwWWBLtterynZrOw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-7.0.0.tgz",
+      "integrity": "sha512-H88kCC+6Vtzj76NsC8rv6x/LW8slBzIbyeSjsKVlS+4qaEJoDrcJR4L+8JdrR2ORdTscrBzYWiiT2jq6leYR1Q==",
       "license": "MIT",
       "dependencies": {
         "css-tree": "^3.0.1",
@@ -4378,90 +4591,89 @@
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.8.2"
+        "stylelint": "^16.8.2 || ^17.0.0"
       }
     },
-    "node_modules/stylelint-scss/node_modules/known-css-properties": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
-      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-      "license": "MIT"
-    },
-    "node_modules/stylelint-scss/node_modules/mdn-data": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.25.0.tgz",
-      "integrity": "sha512-T2LPsjgUE/tgMmRXREVmwsux89DwWfNjiynOeXuLd2mX6jphGQ2YE3Ukz7LQ2VOFKiVZU/Ee1GqzHiipZCjymw==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+    "node_modules/stylelint/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
-    },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "license": "MIT"
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.1.0.tgz",
-      "integrity": "sha512-/pqPFG+FdxWQj+/WSuzXSDaNzxgTLr/OrR1QuqfEZzDakpdYE70PwUxL7BPUa8hpjbvY1+qvCl8k+8Tq34xJgg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+      "integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
       "license": "MIT",
       "dependencies": {
-        "flat-cache": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
+        "flat-cache": "^6.1.20"
       }
     },
     "node_modules/stylelint/node_modules/flat-cache": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
-      "integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
       "license": "MIT",
       "dependencies": {
-        "flatted": "^3.3.1",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=18"
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
       }
     },
     "node_modules/stylelint/node_modules/ignore": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
-      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
-    "node_modules/stylelint/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+    "node_modules/stylelint/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
       "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -4471,19 +4683,43 @@
       }
     },
     "node_modules/supports-hyperlinks": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+      "integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4704,6 +4940,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4847,16 +5095,15 @@
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
   ],
   "dependencies": {
     "stylelint-config-prettier-scss": "^1.0.0",
-    "stylelint-config-recommended-scss": "17.0.0",
-    "stylelint-declaration-strict-value": "1.11.0",
-    "stylelint-order": "7.0.1"
+    "stylelint-config-recommended-scss": "^17.0.0",
+    "stylelint-declaration-strict-value": "^1.11.0",
+    "stylelint-order": "^7.0.1"
   },
   "devDependencies": {
     "@wagtail/eslint-config-wagtail": "^0.4.0",
     "eslint": "^8.57.0",
     "prettier": "^3.3.3",
-    "stylelint": "17.9.0"
+    "stylelint": "^17.9.0"
   },
   "peerDependencies": {
     "stylelint": ">=17.0.0"

--- a/package.json
+++ b/package.json
@@ -28,18 +28,18 @@
   ],
   "dependencies": {
     "stylelint-config-prettier-scss": "^1.0.0",
-    "stylelint-config-recommended-scss": "^14.1.0",
-    "stylelint-declaration-strict-value": "^1.10.6",
-    "stylelint-order": "^6.0.4"
+    "stylelint-config-recommended-scss": "17.0.0",
+    "stylelint-declaration-strict-value": "1.11.0",
+    "stylelint-order": "7.0.1"
   },
   "devDependencies": {
     "@wagtail/eslint-config-wagtail": "^0.4.0",
     "eslint": "^8.57.0",
     "prettier": "^3.3.3",
-    "stylelint": "16.10.0"
+    "stylelint": "17.9.0"
   },
   "peerDependencies": {
-    "stylelint": ">=16.10.0"
+    "stylelint": ">=17.0.0"
   },
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
### Description

Dependency updates:
- stylelint: 16.10.0 → 17.9.0
- stylelint-config-recommended-scss: ^14.1.0 → 17.0.0
- stylelint-declaration-strict-value: ^1.10.6 → 1.11.0
- stylelint-order: ^6.0.4 → 7.0.1

Breaking changes addressed:
- Replaced selector-class-pattern with scss/selector-class-pattern to retain resolveNestedSelectors option removed in Stylelint 17

See: https://stylelint.io/migration-guide/to-17

### AI usage

100% AI generated

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the package to Stylelint v17, bumping `stylelint-config-recommended-scss` to v17, `stylelint-order` to v7, and `stylelint-declaration-strict-value` to v1.11. The key code change replaces the core `selector-class-pattern` rule with `scss/selector-class-pattern` to retain the `resolveNestedSelectors` option that Stylelint 17 removed from the built-in rule.

- The `peerDependencies` entry in `package-lock.json` still reads `>=16.10.0` instead of `>=17.0.0`, indicating the lock file was not regenerated after `package.json` was updated — running `npm install` should fix this.
- The plugin dependencies were switched from semver ranges to exact versions (`17.0.0`, `1.11.0`, `7.0.1`); for a published config library, `^` ranges are conventional to let consumers receive compatible patch/security updates without a new release of this package.

<h3>Confidence Score: 4/5</h3>

Safe to merge after regenerating package-lock.json to fix the stale peerDependencies entry; exact version pinning is a minor style concern.

One P1 finding: the package-lock.json peerDependencies entry was not updated to match package.json (still shows >=16.10.0). The core rule migration is correct, tests pass with the updated expectations, and the CHANGELOG/README are comprehensive. Fixing the lock file inconsistency should be straightforward.

package-lock.json — peerDependencies entry needs regeneration to match package.json's >=17.0.0 constraint.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| index.js | Core rule change: replaces `selector-class-pattern` with `scss/selector-class-pattern` to preserve `resolveNestedSelectors` option dropped from Stylelint 17's core rule. Straightforward and correct migration. |
| __tests__/index.test.mjs | Test expectations updated: rule name `selector-class-pattern` → `scss/selector-class-pattern`, warning count updated from 47 → 46, and `selector-max-combinators` count from 2 → 1 (reflecting Stylelint 17's changed nesting desugaring behavior). |
| package.json | Upgrades stylelint peer dependency floor to >=17.0.0 and bumps plugin dependencies, but switches from semver ranges to exact version pinning for all three plugin packages — unusual for a published config library. |
| package-lock.json | Dependency tree updated for Stylelint 17, but the root workspace `peerDependencies` entry still shows `>=16.10.0` instead of `>=17.0.0`, indicating the lock file was not fully regenerated after the package.json peer dependency update. |
| CHANGELOG.md | Documents the Stylelint 17 upgrade, breaking changes, and migration notes clearly including the `selector-class-pattern` → `scss/selector-class-pattern` substitution and nesting rule behavior changes. |
| README.md | Rules table updated with ~10 new rules from Stylelint 17 (e.g., `at-rule-no-deprecated`, `property-no-deprecated`, `syntax-string-no-invalid`, `nesting-selector-no-missing-scoping-root`) and all reference indices renumbered. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer project] -->|installs| B["@wagtail/stylelint-config-wagtail"]
    B -->|extends| C["stylelint-config-recommended-scss v17"]
    B -->|extends| D["stylelint-config-prettier-scss"]
    B -->|plugin| E["stylelint-declaration-strict-value v1.11"]
    B -->|plugin| F["stylelint-order v7"]
    C -->|requires| G["stylelint >= 17.0.0"]
    B -->|peerDep| G

    subgraph "Breaking change in index.js"
        H["selector-class-pattern (removed)"]
        I["scss/selector-class-pattern (added)\nresolveNestedSelectors: true"]
        H -->|replaced by| I
    end
```

<sub>Reviews (1): Last reviewed commit: ["Upgrade to Stylelint v17"](https://github.com/wagtail/stylelint-config-wagtail/commit/c099312b4a231eb7052555574a9a10fa2b41d2b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29473738)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->